### PR TITLE
Use consistent naming for neuron and layer defines

### DIFF
--- a/include/nn_layer.h
+++ b/include/nn_layer.h
@@ -7,32 +7,32 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-// LAYER_MAX_INPUT_SIZE defines the maximum input size a layer can have.
-#ifndef LAYER_MAX_INPUT_SIZE
-#define LAYER_MAX_INPUT_SIZE 64
+// NN_LAYER_MAX_INPUT_SIZE defines the maximum input size a layer can have.
+#ifndef NN_LAYER_MAX_INPUT_SIZE
+#define NN_LAYER_MAX_INPUT_SIZE 64
 #endif
 
-// LAYER_MAX_OUTPUT_SIZE defines the maximum output size a layer can have.
-#ifndef LAYER_MAX_OUTPUT_SIZE
-#define LAYER_MAX_OUTPUT_SIZE 64
+// NN_LAYER_MAX_OUTPUT_SIZE defines the maximum output size a layer can have.
+#ifndef NN_LAYER_MAX_OUTPUT_SIZE
+#define NN_LAYER_MAX_OUTPUT_SIZE 64
 #endif
 
-// LAYER_MAX_BIASES defines the maximum number of biases a layer can have.
-#ifndef LAYER_MAX_BIASES
-#define LAYER_MAX_BIASES 64
+// NN_LAYER_MAX_BIASES defines the maximum number of biases a layer can have.
+#ifndef NN_LAYER_MAX_BIASES
+#define NN_LAYER_MAX_BIASES 64
 #endif
 
-// LAYER_MAX_BATCH_SIZE defines the maximum batch size a layer can have.
-#ifndef LAYER_MAX_BATCH_SIZE
-#define LAYER_MAX_BATCH_SIZE 32
+// NN_LAYER_MAX_BATCH_SIZE defines the maximum batch size a layer can have.
+#ifndef NN_LAYER_MAX_BATCH_SIZE
+#define NN_LAYER_MAX_BATCH_SIZE 32
 #endif
 
 // NNLayer represents a single layer in a neural network.
 typedef struct {
     size_t input_size;
     size_t output_size;
-    float weights[LAYER_MAX_OUTPUT_SIZE][LAYER_MAX_INPUT_SIZE];
-    float biases[LAYER_MAX_BIASES];
+    float weights[NN_LAYER_MAX_OUTPUT_SIZE][NN_LAYER_MAX_INPUT_SIZE];
+    float biases[NN_LAYER_MAX_BIASES];
     NNActivationFunction act_func;
     NNDotProductFunction dot_product_func;
 } NNLayer;
@@ -41,12 +41,12 @@ typedef struct {
 bool nn_layer_init(NNLayer *layer, size_t input_size, size_t output_size, NNActivationFunction act_func, NNDotProductFunction dot_product_func, NNError *error);
 
 // nn_layer_set_weights sets the weights of the given layer.
-bool nn_layer_set_weights(NNLayer *layer, const float weights[LAYER_MAX_OUTPUT_SIZE][LAYER_MAX_INPUT_SIZE], NNError *error);
+bool nn_layer_set_weights(NNLayer *layer, const float weights[NN_LAYER_MAX_OUTPUT_SIZE][NN_LAYER_MAX_INPUT_SIZE], NNError *error);
 
 // nn_layer_set_biases sets the biases of the given layer.
-bool nn_layer_set_biases(NNLayer *layer, const float biases[LAYER_MAX_BIASES], NNError *error);
+bool nn_layer_set_biases(NNLayer *layer, const float biases[NN_LAYER_MAX_BIASES], NNError *error);
 
 // nn_layer_compute computes the given layer with the given inputs and stores the result in outputs.
-bool nn_layer_compute(const NNLayer *layer, const float inputs[LAYER_MAX_BATCH_SIZE][LAYER_MAX_INPUT_SIZE], float outputs[LAYER_MAX_BATCH_SIZE][LAYER_MAX_OUTPUT_SIZE], size_t batch_size, NNError *error);
+bool nn_layer_compute(const NNLayer *layer, const float inputs[NN_LAYER_MAX_BATCH_SIZE][NN_LAYER_MAX_INPUT_SIZE], float outputs[NN_LAYER_MAX_BATCH_SIZE][NN_LAYER_MAX_OUTPUT_SIZE], size_t batch_size, NNError *error);
 
 #endif // NN_LAYER_H

--- a/include/nn_neuron.h
+++ b/include/nn_neuron.h
@@ -7,16 +7,16 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-// NEURON_MAX_WEIGHTS defines the maximum number of weights a neuron can have.
-#ifndef NEURON_MAX_WEIGHTS
-#define NEURON_MAX_WEIGHTS 64
+// NN_NEURON_MAX_WEIGHTS defines the maximum number of weights a neuron can have.
+#ifndef NN_NEURON_MAX_WEIGHTS
+#define NN_NEURON_MAX_WEIGHTS 64
 #endif
 
 // NNNeuron represents a single neuron in a neural network.
 // It is intended for experimentation and prototyping, and not recommended for
 // real-world applications since it's not optimized for performance.
 typedef struct {
-    float weights[NEURON_MAX_WEIGHTS];
+    float weights[NN_NEURON_MAX_WEIGHTS];
     size_t input_size;
     float bias;
     NNActivationFunction act_func;
@@ -24,15 +24,15 @@ typedef struct {
 } NNNeuron;
 
 // nn_neuron_init initializes a neuron with the given arguments.
-bool nn_neuron_init(NNNeuron *neuron, const float weights[NEURON_MAX_WEIGHTS], size_t input_size, float bias, NNActivationFunction act_func, NNDotProductFunction dot_product_func, NNError *error);
+bool nn_neuron_init(NNNeuron *neuron, const float weights[NN_NEURON_MAX_WEIGHTS], size_t input_size, float bias, NNActivationFunction act_func, NNDotProductFunction dot_product_func, NNError *error);
 
 // nn_neuron_set_weights sets the weights of the given neuron.
-bool nn_neuron_set_weights(NNNeuron *neuron, const float weights[NEURON_MAX_WEIGHTS], NNError *error);
+bool nn_neuron_set_weights(NNNeuron *neuron, const float weights[NN_NEURON_MAX_WEIGHTS], NNError *error);
 
 // nn_neuron_set_bias sets the bias of the given neuron.
 bool nn_neuron_set_bias(NNNeuron *neuron, float bias, NNError *error);
 
 // nn_neuron_compute computes the given neuron and returns the output.
-float nn_neuron_compute(const NNNeuron *neuron, const float inputs[NEURON_MAX_WEIGHTS], NNError *error);
+float nn_neuron_compute(const NNNeuron *neuron, const float inputs[NN_NEURON_MAX_WEIGHTS], NNError *error);
 
 #endif // NN_NEURON_H

--- a/src/nn_layer.c
+++ b/src/nn_layer.c
@@ -30,7 +30,7 @@ bool nn_layer_init(NNLayer *layer, size_t input_size, size_t output_size, NNActi
 }
 
 // nn_layer_set_weights sets the weights of the given layer.
-bool nn_layer_set_weights(NNLayer *layer, const float weights[LAYER_MAX_OUTPUT_SIZE][LAYER_MAX_INPUT_SIZE], NNError *error) {
+bool nn_layer_set_weights(NNLayer *layer, const float weights[NN_LAYER_MAX_OUTPUT_SIZE][NN_LAYER_MAX_INPUT_SIZE], NNError *error) {
     nn_error_set(error, NN_ERROR_NONE, NULL);
     if (layer == NULL) {
         nn_error_set(error, NN_ERROR_INVALID_INSTANCE, "layer is NULL");
@@ -45,7 +45,7 @@ bool nn_layer_set_weights(NNLayer *layer, const float weights[LAYER_MAX_OUTPUT_S
 }
 
 // nn_layer_set_biases sets the biases of the given layer.
-bool nn_layer_set_biases(NNLayer *layer, const float biases[LAYER_MAX_BIASES], NNError *error) {
+bool nn_layer_set_biases(NNLayer *layer, const float biases[NN_LAYER_MAX_BIASES], NNError *error) {
     nn_error_set(error, NN_ERROR_NONE, NULL);
     if (layer == NULL) {
         nn_error_set(error, NN_ERROR_INVALID_INSTANCE, "layer is NULL");
@@ -58,7 +58,7 @@ bool nn_layer_set_biases(NNLayer *layer, const float biases[LAYER_MAX_BIASES], N
 }
 
 // nn_layer_compute computes the given layer with the given inputs and stores the result in outputs.
-bool nn_layer_compute(const NNLayer *layer, const float inputs[LAYER_MAX_BATCH_SIZE][LAYER_MAX_INPUT_SIZE], float outputs[LAYER_MAX_BATCH_SIZE][LAYER_MAX_OUTPUT_SIZE], size_t batch_size, NNError *error) {
+bool nn_layer_compute(const NNLayer *layer, const float inputs[NN_LAYER_MAX_BATCH_SIZE][NN_LAYER_MAX_INPUT_SIZE], float outputs[NN_LAYER_MAX_BATCH_SIZE][NN_LAYER_MAX_OUTPUT_SIZE], size_t batch_size, NNError *error) {
     nn_error_set(error, NN_ERROR_NONE, NULL);
     if (layer == NULL) {
         nn_error_set(error, NN_ERROR_INVALID_INSTANCE, "layer is NULL");

--- a/src/nn_neuron.c
+++ b/src/nn_neuron.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 
 // nn_neuron_init initializes a neuron with the given arguments.
-bool nn_neuron_init(NNNeuron *neuron, const float weights[NEURON_MAX_WEIGHTS], size_t input_size, float bias, NNActivationFunction act_func, NNDotProductFunction dot_product_func, NNError *error) {
+bool nn_neuron_init(NNNeuron *neuron, const float weights[NN_NEURON_MAX_WEIGHTS], size_t input_size, float bias, NNActivationFunction act_func, NNDotProductFunction dot_product_func, NNError *error) {
     nn_error_set(error, NN_ERROR_NONE, NULL);
     if (neuron == NULL) {
         nn_error_set(error, NN_ERROR_INVALID_INSTANCE, "neuron is NULL");
@@ -32,7 +32,7 @@ bool nn_neuron_init(NNNeuron *neuron, const float weights[NEURON_MAX_WEIGHTS], s
 }
 
 // nn_neuron_set_weights sets the weights of the given neuron.
-bool nn_neuron_set_weights(NNNeuron *neuron, const float weights[NEURON_MAX_WEIGHTS], NNError *error) {
+bool nn_neuron_set_weights(NNNeuron *neuron, const float weights[NN_NEURON_MAX_WEIGHTS], NNError *error) {
     nn_error_set(error, NN_ERROR_NONE, NULL);
     if (neuron == NULL) {
         nn_error_set(error, NN_ERROR_INVALID_INSTANCE, "neuron is NULL");
@@ -56,7 +56,7 @@ bool nn_neuron_set_bias(NNNeuron *neuron, float bias, NNError *error) {
 }
 
 // nn_neuron_compute computes the given neuron and returns the output.
-float nn_neuron_compute(const NNNeuron *neuron, const float inputs[NEURON_MAX_WEIGHTS], NNError *error) {
+float nn_neuron_compute(const NNNeuron *neuron, const float inputs[NN_NEURON_MAX_WEIGHTS], NNError *error) {
     nn_error_set(error, NN_ERROR_NONE, NULL);
     if (neuron == NULL) {
         nn_error_set(error, NN_ERROR_INVALID_INSTANCE, "neuron is NULL");

--- a/tests/arch/arm/cmsis-dsp/neuron/main.c
+++ b/tests/arch/arm/cmsis-dsp/neuron/main.c
@@ -13,8 +13,8 @@
 
 // TestCase defines a single test case.
 typedef struct {
-    float inputs[NEURON_MAX_WEIGHTS];
-    float weights[NEURON_MAX_WEIGHTS];
+    float inputs[NN_NEURON_MAX_WEIGHTS];
+    float weights[NN_NEURON_MAX_WEIGHTS];
     size_t input_size;
     float bias;
     NNDotProductFunction dot_product_func;

--- a/tests/arch/arm/cmsis-dsp/neuron_perf/main.c
+++ b/tests/arch/arm/cmsis-dsp/neuron_perf/main.c
@@ -19,7 +19,7 @@ int main(int argc, char *argv[]) {
     NNNeuron neuron;
     NNError error;
     size_t input_size = 3;
-    float weights[NEURON_MAX_WEIGHTS] = {0.2f, 0.8f, -0.5f};
+    float weights[NN_NEURON_MAX_WEIGHTS] = {0.2f, 0.8f, -0.5f};
     float bias = 2.0f;
     const int n_runs = 1000;
     const int n_inputs = n_runs * input_size;

--- a/tests/arch/arm/neon/neuron/main.c
+++ b/tests/arch/arm/neon/neuron/main.c
@@ -13,8 +13,8 @@
 
 // TestCase defines a single test case.
 typedef struct {
-    float inputs[NEURON_MAX_WEIGHTS];
-    float weights[NEURON_MAX_WEIGHTS];
+    float inputs[NN_NEURON_MAX_WEIGHTS];
+    float weights[NN_NEURON_MAX_WEIGHTS];
     size_t input_size;
     float bias;
     NNDotProductFunction dot_product_func;

--- a/tests/arch/arm/neon/neuron_perf/main.c
+++ b/tests/arch/arm/neon/neuron_perf/main.c
@@ -20,7 +20,7 @@ int main(int argc, char *argv[]) {
     NNNeuron neuron;
     NNError error;
     size_t input_size = 3;
-    float weights[NEURON_MAX_WEIGHTS] = {0.2f, 0.8f, -0.5f};
+    float weights[NN_NEURON_MAX_WEIGHTS] = {0.2f, 0.8f, -0.5f};
     float bias = 2.0f;
     const int n_runs = 1000;
     const int n_inputs = n_runs * input_size;

--- a/tests/arch/generic/layer/main.c
+++ b/tests/arch/generic/layer/main.c
@@ -16,14 +16,14 @@
 typedef struct {
     size_t input_size;
     size_t output_size;
-    float weights[LAYER_MAX_OUTPUT_SIZE][LAYER_MAX_INPUT_SIZE];
-    float biases[LAYER_MAX_BIASES];
+    float weights[NN_LAYER_MAX_OUTPUT_SIZE][NN_LAYER_MAX_INPUT_SIZE];
+    float biases[NN_LAYER_MAX_BIASES];
     NNActivationFunction act_func;
     NNDotProductFunction dot_product_func;
     size_t batch_size;
-    float inputs[LAYER_MAX_BATCH_SIZE][LAYER_MAX_INPUT_SIZE];
+    float inputs[NN_LAYER_MAX_BATCH_SIZE][NN_LAYER_MAX_INPUT_SIZE];
     float output_tolerance;
-    float expected_outputs[LAYER_MAX_BATCH_SIZE][LAYER_MAX_OUTPUT_SIZE];
+    float expected_outputs[NN_LAYER_MAX_BATCH_SIZE][NN_LAYER_MAX_OUTPUT_SIZE];
 } TestCase;
 
 // run_test_cases runs the test cases.
@@ -39,7 +39,7 @@ void run_test_cases(TestCase *test_cases, int n_cases, char *info) {
         assert(error.code == NN_ERROR_NONE);
         nn_layer_set_biases(&layer, tc.biases, &error);
         assert(error.code == NN_ERROR_NONE);
-        float outputs[LAYER_MAX_BATCH_SIZE][LAYER_MAX_OUTPUT_SIZE];
+        float outputs[NN_LAYER_MAX_BATCH_SIZE][NN_LAYER_MAX_OUTPUT_SIZE];
         const bool success = nn_layer_compute(&layer, tc.inputs, outputs, tc.batch_size, &error);
         assert(success == true);
         assert(error.code == NN_ERROR_NONE);

--- a/tests/arch/generic/neuron/main.c
+++ b/tests/arch/generic/neuron/main.c
@@ -12,8 +12,8 @@
 
 // TestCase defines a single test case.
 typedef struct {
-    float inputs[NEURON_MAX_WEIGHTS];
-    float weights[NEURON_MAX_WEIGHTS];
+    float inputs[NN_NEURON_MAX_WEIGHTS];
+    float weights[NN_NEURON_MAX_WEIGHTS];
     size_t input_size;
     float bias;
     NNDotProductFunction dot_product_func;

--- a/tests/arch/generic/neuron_perf/main.c
+++ b/tests/arch/generic/neuron_perf/main.c
@@ -14,7 +14,7 @@ int main(int argc, char *argv[]) {
     NNNeuron neuron;
     NNError error;
     size_t input_size = 3;
-    float weights[NEURON_MAX_WEIGHTS] = {0.2f, 0.8f, -0.5f};
+    float weights[NN_NEURON_MAX_WEIGHTS] = {0.2f, 0.8f, -0.5f};
     float bias = 2.0f;
     const int n_runs = 1000;
     const int n_inputs = n_runs * input_size;


### PR DESCRIPTION
Use consistent naming for neuron and layer defines.